### PR TITLE
Build improvements

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -23,4 +23,4 @@ jobs:
     - name: make
       run: cd build && make -j2 && make wheel
     - name: make check
-      run: cd build && ctest && make pytest
+      run: cd build && ctest --output-on-failure && make pytest

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,6 +16,7 @@ jobs:
     - name: install
       run: |
         sudo apt -y install cmake libjpeg-dev libtiff-dev freeglut3-dev libxi-dev libxmu-dev
+        sudo apt -y install xvfb
         sudo apt -y install python3-pytest python3-numpy python3-matplotlib python3-wheel
         python3 -m pip install numpy pytest matplotlib wheel --user
     - name: configure
@@ -23,4 +24,4 @@ jobs:
     - name: make
       run: cd build && make -j2 && make wheel
     - name: make check
-      run: cd build && ctest --output-on-failure && make pytest
+      run: cd build && xvfb-run --auto-servernum ctest --output-on-failure && xvfb-run --auto-servernum make pytest

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -23,4 +23,4 @@ jobs:
     - name: make
       run: cd build && make -j2 && make wheel
     - name: make check
-      run: cd build && make pytest
+      run: cd build && ctest && make pytest

--- a/source/python/CMakeLists.txt
+++ b/source/python/CMakeLists.txt
@@ -45,13 +45,12 @@ add_custom_target(wheel DEPENDS _smoldyn
     COMMENT "Generating wheel in ${CMAKE_BINARY_DIR}"
     VERBATIM)
 
-# This target is for developers.
-add_custom_target(pyinstall
-    DEPENDS _smoldyn
-    COMMAND ${PYTHON_EXECUTABLE} setup.py develop
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMENT "installing in developer mode.")
-    #VERBATIM)
+  add_custom_target(pyinstall
+    COMMAND ${PYTHON_EXECUTABLE} setup.py install 
+      --prefix ${CMAKE_INSTALL_PREFIX}
+    WORKING_DIRECTORY ${PY_SMOLDYN_OUTDIR}
+    COMMENT "RUNNING: python3 setup.py install --prefix ${CMAKE_INSTALL_PREFIX}"
+    VERBATIM)
 
 add_custom_target(pyinstall_venv
     DEPENDS _smoldyn
@@ -84,7 +83,7 @@ foreach(_pyscript ${TEST_SCRIPTS})
         ${PYTHON_EXECUTABLE} ${_pyscript}
         WORKING_DIRECTORY ${_test_dir})
     set_tests_properties(${_test_name} PROPERTIES 
-        ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}")
+      ENVIRONMENT "PYTHONPATH=${PY_SMOLDYN_OUTDIR}")
 endforeach()
 
 # Run tests using pytest.

--- a/source/python/CMakeLists.txt
+++ b/source/python/CMakeLists.txt
@@ -11,6 +11,9 @@ else()
     set(PYTHON_INCLUDE_DIRS ${Python3_INCLUDE_DIRS})
 endif()
 
+set(PY_SMOLDYN_OUTDIR ${CMAKE_BINARY_DIR}/py)
+file(MAKE_DIRECTORY ${PY_SMOLDYN_OUTDIR})
+
 pybind11_add_module(_smoldyn MODULE Smoldyn.cpp module.cpp)
 
 target_compile_options(_smoldyn PRIVATE -DSMOLDYN_VERSION=${SMOLDYN_VERSION})
@@ -20,15 +23,21 @@ target_include_directories(_smoldyn PRIVATE
 
 set_target_properties(_smoldyn PROPERTIES 
     SUFFIX ".so"
-    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/smoldyn)
+    LIBRARY_OUTPUT_DIRECTORY ${PY_SMOLDYN_OUTDIR}/smoldyn/)
 
 add_dependencies(_smoldyn smoldyn_static)
 
 target_link_libraries(_smoldyn PRIVATE smoldyn_static)
 
+add_custom_command(TARGET _smoldyn POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${CMAKE_SOURCE_DIR}/source/python/smoldyn ${PY_SMOLDYN_OUTDIR}/smoldyn
+  COMMENT "Copying python source tree to binary directory"
+  VERBATIM)
+
 # copy setup.py.in to setup.py
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in
-    ${CMAKE_CURRENT_SOURCE_DIR}/setup.py)
+    ${PY_SMOLDYN_OUTDIR}/setup.py)
 
 add_custom_target(wheel DEPENDS _smoldyn 
     COMMAND ${PYTHON_EXECUTABLE} setup.py bdist_wheel -d ${CMAKE_BINARY_DIR}
@@ -43,12 +52,11 @@ add_custom_target(pyinstall
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "installing in developer mode.")
     #VERBATIM)
-    
 
 add_custom_target(pyinstall_venv
     DEPENDS _smoldyn
     COMMAND ${PYTHON_EXECUTABLE} setup.py install
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    WORKING_DIRECTORY ${PY_SMOLDYN_OUTDIR}
     COMMENT "RUNNING: python3 setup.py install"
     VERBATIM)
 
@@ -60,10 +68,9 @@ add_custom_target(pyuninstall
 add_custom_target(pydevel
     DEPENDS _smoldyn
     COMMAND ${PYTHON_EXECUTABLE} setup.py develop --user
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    WORKING_DIRECTORY ${PY_SMOLDYN_OUTDIR}
     COMMENT "RUNNING: python3 setup.py develop --user"
     VERBATIM)
-
 
 enable_testing()
 

--- a/source/python/CMakeLists.txt
+++ b/source/python/CMakeLists.txt
@@ -41,7 +41,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in
 
 add_custom_target(wheel DEPENDS _smoldyn 
     COMMAND ${PYTHON_EXECUTABLE} setup.py bdist_wheel -d ${CMAKE_BINARY_DIR}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    WORKING_DIRECTORY ${PY_SMOLDYN_OUTDIR}
     COMMENT "Generating wheel in ${CMAKE_BINARY_DIR}"
     VERBATIM)
 


### PR DESCRIPTION
- Builds python module out of source: `py` directory in the current build directory. Set PYTHONPATH to `/path/to/current/build_dir/py`.
- `make test` runs in-built tests. For these tests, one need not set PYTHONPATH.
- `make pyinstall` passes `CMAKE_INSTALL_PREFIX` to `--prefix` option to `setup.py`. 